### PR TITLE
feat(mvvm): Actually use MVVM practices

### DIFF
--- a/NeosPlusLauncher/NeosPlusLauncher/FodyWeavers.xml
+++ b/NeosPlusLauncher/NeosPlusLauncher/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+	<ReactiveUI />
+</Weavers>

--- a/NeosPlusLauncher/NeosPlusLauncher/MainWindow.axaml
+++ b/NeosPlusLauncher/NeosPlusLauncher/MainWindow.axaml
@@ -38,6 +38,7 @@
 				<Button x:Name="InstallButton" Margin="10,20,10,0" Padding="8,5"
                         Content="Install/Update"
                         Command="{Binding InstallCommand}"
+						IsEnabled="{Binding InstallEnabled}"
                         Background="#333333"
                         BorderThickness="1"
                         BorderBrush="#333333"

--- a/NeosPlusLauncher/NeosPlusLauncher/NeosPlusLauncher.csproj
+++ b/NeosPlusLauncher/NeosPlusLauncher/NeosPlusLauncher.csproj
@@ -23,6 +23,7 @@
 		<PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-rc1.1" />
 		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-rc1.1" />
 		<PackageReference Include="Octokit" Version="6.0.0" />
+		<PackageReference Include="ReactiveUI.Fody" Version="19.2.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NeosPlusLauncher/NeosPlusLauncher/ViewModels/Download.cs
+++ b/NeosPlusLauncher/NeosPlusLauncher/ViewModels/Download.cs
@@ -23,7 +23,7 @@ namespace NeosPlusLauncher.ViewModels
         private const string RepositoryOwner = "Xlinka";
         private const string RepositoryName = "NeosPlus";
 
-        public static async Task<DownloadResult> DownloadAndInstallNeosPlus(string neosPath, string neosPlusDirector)
+        public static async Task<DownloadResult> DownloadAndInstallNeosPlus(string neosPath, string neosPlusDirectory)
         {
             string neosPlusDir = Path.Combine(neosPath, "Libraries", "NeosPlus");
             Directory.CreateDirectory(neosPlusDir);

--- a/NeosPlusLauncher/NeosPlusLauncher/ViewModels/Download.cs
+++ b/NeosPlusLauncher/NeosPlusLauncher/ViewModels/Download.cs
@@ -8,12 +8,22 @@ using Octokit;
 
 namespace NeosPlusLauncher.ViewModels
 {
+    public struct DownloadResult
+    {
+        public readonly bool Succes = false;
+        public string Message = string.Empty;
+        public DownloadResult(bool success, string message)
+        {
+            Succes = success;
+            Message = message;
+        }
+    }
     public static class Download
     {
         private const string RepositoryOwner = "Xlinka";
         private const string RepositoryName = "NeosPlus";
 
-        public static async Task<bool> DownloadAndInstallNeosPlus(string neosPath, string neosPlusDirectory, TextBlock statusTextBlock, Button installButton)
+        public static async Task<DownloadResult> DownloadAndInstallNeosPlus(string neosPath, string neosPlusDirector)
         {
             string neosPlusDir = Path.Combine(neosPath, "Libraries", "NeosPlus");
             Directory.CreateDirectory(neosPlusDir);
@@ -30,11 +40,6 @@ namespace NeosPlusLauncher.ViewModels
                 string latestReleaseUrl = latestRelease.Assets[0].BrowserDownloadUrl;
                 string localZipFilePath = Path.Combine(neosPlusDir, $"NeosPlus_{latestRelease.TagName}.zip");
 
-                await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
-                {
-                    statusTextBlock.Text = "Downloading NeosPlus...";
-                });
-
                 try
                 {
                     using (HttpClient httpClient = new HttpClient())
@@ -43,12 +48,7 @@ namespace NeosPlusLauncher.ViewModels
 
                         if (!response.IsSuccessStatusCode)
                         {
-                            await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
-                            {
-                                statusTextBlock.Text = "Failed to download NeosPlus.";
-                                installButton.IsEnabled = true;
-                            });
-                            return false;
+                            return new DownloadResult(false, "Failed to download NeosPlus.");
                         }
 
                         using (Stream contentStream = await response.Content.ReadAsStreamAsync(),
@@ -67,31 +67,16 @@ namespace NeosPlusLauncher.ViewModels
                     // Update the version information in the version.txt file
                     await File.WriteAllTextAsync(versionFilePath, latestRelease.TagName);
 
-                    await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
-                    {
-                        statusTextBlock.Text = "NeosPlus downloaded and installed successfully.";
-                    });
-
-                    return true;
+                    return new DownloadResult(true, "NeosPlus downloaded and installed successfully.");
                 }
                 catch (Exception ex)
                 {
-                    await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
-                    {
-                        statusTextBlock.Text = $"Failed to download or install NeosPlus: {ex.Message}";
-                        installButton.IsEnabled = true;
-                    });
-                    return false;
+                    return new DownloadResult(false, $"Failed to download or install NeosPlus: {ex.Message}");
                 }
             }
             else
             {
-                await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() =>
-                {
-                    statusTextBlock.Text = "NeosPlus is up-to-date.";
-                });
-
-                return true;
+                return new DownloadResult(false, $"NeosPlus is up-to-date.");
             }
         }
     }


### PR DESCRIPTION
The whole point of MVVM is to not explicitly refer to a view from the view model layer. The view and view model communicate via properties and commands.

What this means is that you have a separation of concerns between your views and your application logic.

This generically means, "Never Use Find Control".

Doing this also means you can kill most of your scheduling code, because you're not actually touching the UI thread, Avalonia's binding system is doing the marshalling between UI and non-ui code for you.

I also threw in Reactive Fody stuff which means you can get rid of a lot of boilerplate.

I think this still works but of course cannot 100% test because of the change between DLL and Zips.

tl;dr 
![image](https://github.com/Xlinka/NeosPlusLauncher/assets/8791132/8051055f-a29c-4b76-9e3b-cd7f4a526e0b)
