### PR TITLE
Add Steam launch option for Linux users

### DIFF
--- a/NeosPlusLauncher/NeosPlusLauncher/MainWindow.axaml
+++ b/NeosPlusLauncher/NeosPlusLauncher/MainWindow.axaml
@@ -34,26 +34,38 @@
 				<RowDefinition Height="Auto" />
 			</Grid.RowDefinitions>
 			<TextBlock Grid.Row="1" Margin="0,20,0,0" Text="NeosPlus Launcher" FontSize="24" FontWeight="Bold" Foreground="#FFFFFF" HorizontalAlignment="Center" FontFamily="Segoe UI" />
-			<StackPanel Grid.Row="2" HorizontalAlignment="Center" Orientation="Horizontal">
-				<Button x:Name="InstallButton" Margin="10,20,10,0" Padding="8,5"
-                        Content="Install/Update"
-                        Command="{Binding InstallCommand}"
-						IsEnabled="{Binding InstallEnabled}"
-                        Background="#333333"
-                        BorderThickness="1"
-                        BorderBrush="#333333"
-                        CornerRadius="20"
-                        Foreground="#FFFFFF"
-                        FontFamily="Segoe UI" />
-				<Button x:Name="LaunchButton" Margin="10,20,10,0" Padding="8,5"
-                        Content="Launch"
-                        Command="{Binding LaunchCommand}"
-                        Background="#333333"
-                        BorderThickness="1"
-                        BorderBrush="#333333"
-                        CornerRadius="20"
-                        Foreground="#FFFFFF"
-                        FontFamily="Segoe UI" />
+
+			<StackPanel Grid.Row="2" HorizontalAlignment="Center" Orientation="Vertical">
+				<CheckBox IsThreeState="False"
+							IsChecked="{Binding SteamRunEnabled}"
+							Content="Use Steam (Linux only)"
+							Background="#333333"
+							BorderThickness="1"
+							BorderBrush="#333333"
+							CornerRadius="20"
+							Foreground="#FFFFFF"
+							FontFamily="Segoe UI" />
+				<StackPanel Grid.Row="2" HorizontalAlignment="Center" Orientation="Horizontal">
+					<Button x:Name="InstallButton" Margin="10,20,10,0" Padding="8,5"
+							Content="Install/Update"
+							Command="{Binding InstallCommand}"
+							IsEnabled="{Binding InstallEnabled}"
+							Background="#333333"
+							BorderThickness="1"
+							BorderBrush="#333333"
+							CornerRadius="20"
+							Foreground="#FFFFFF"
+							FontFamily="Segoe UI" />
+					<Button x:Name="LaunchButton" Margin="10,20,10,0" Padding="8,5"
+							Content="Launch"
+							Command="{Binding LaunchCommand}"
+							Background="#333333"
+							BorderThickness="1"
+							BorderBrush="#333333"
+							CornerRadius="20"
+							Foreground="#FFFFFF"
+							FontFamily="Segoe UI" />
+				</StackPanel>
 			</StackPanel>
 			<TextBlock x:Name="StatusTextBlock" Grid.Row="3" Margin="0,10,0,0" Text="{Binding StatusText}" Foreground="#FFFFFF" HorizontalAlignment="Center" FontFamily="Segoe UI" />
 			<StackPanel Grid.Row="4" Margin="0,10,0,0" Orientation="Vertical">

--- a/NeosPlusLauncher/NeosPlusLauncher/MainWindow.axaml
+++ b/NeosPlusLauncher/NeosPlusLauncher/MainWindow.axaml
@@ -36,7 +36,7 @@
 			<TextBlock Grid.Row="1" Margin="0,20,0,0" Text="NeosPlus Launcher" FontSize="24" FontWeight="Bold" Foreground="#FFFFFF" HorizontalAlignment="Center" FontFamily="Segoe UI" />
 
 			<StackPanel Grid.Row="2" HorizontalAlignment="Center" Orientation="Vertical">
-				<CheckBox IsThreeState="False"
+				<CheckBox 	IsThreeState="False" Margin="10,20,10,0" Padding="8,5"
 							IsChecked="{Binding SteamRunEnabled}"
 							Content="Use Steam (Linux only)"
 							Background="#333333"

--- a/NeosPlusLauncher/NeosPlusLauncher/ViewModels/MainWindowViewModel.cs
+++ b/NeosPlusLauncher/NeosPlusLauncher/ViewModels/MainWindowViewModel.cs
@@ -155,7 +155,7 @@ namespace NeosPlusLauncher.ViewModels
             }
             else
             {
-                neosExePath = Path.Combine(neosPath, "Neos.exe");
+                neosExePath = Path.Combine(neosPath, "neos.exe");
                 arguments = $"-LoadAssembly \"{neosPlusDllPath}\"";
             }
 

--- a/NeosPlusLauncher/NeosPlusLauncher/ViewModels/MainWindowViewModel.cs
+++ b/NeosPlusLauncher/NeosPlusLauncher/ViewModels/MainWindowViewModel.cs
@@ -143,11 +143,12 @@ namespace NeosPlusLauncher.ViewModels
             string arguments;
             if (SteamRunEnabled)
             {
-                // Should technically work even with flatpak steam
+                // Without that, xdg-open will interprete slashes incorrectly
                 neosExePath = "sh";
-                // Absolute path with replaced forward slashes doesn't work
+                // Absolute path replaced with relative, absolute doesn't work with steam run
                 neosPlusDllPath = neosPlusDllPath.Replace(neosPath + "/", "");
-                // Only double forward slashes worked with steam run, not backslashes
+                // Only double backslashes worked with steam run, not forward slashes
+                // And for it to work inside sh, it needs another double backslash
                 neosPlusDllPath = neosPlusDllPath.Replace("/", "\\\\");
                 // Single quote is essential for steam run as well
                 arguments = $"-c \"xdg-open steam://run/740250//'-LoadAssembly {neosPlusDllPath}";
@@ -170,7 +171,7 @@ namespace NeosPlusLauncher.ViewModels
             }
             if (SteamRunEnabled)
             {
-                // Here we close entire argument for steam run
+                // Here we close entire argument for steam run, as well as for sh
                 arguments += "'\"";
             }
 


### PR DESCRIPTION
This is so that Linux users could launch game using Proton through Steam.

Works with flatpak, host steam (through xdg-open).

![image](https://github.com/Xlinka/NeosPlusLauncher/assets/7141787/83c8ec9c-641a-46d4-85fa-f9a9e499a988)
